### PR TITLE
Add E2E tests using k1LoW/runn

### DIFF
--- a/runn/grpc_list.yml
+++ b/runn/grpc_list.yml
@@ -1,0 +1,25 @@
+version: "0"
+desc: Test gRPC List endpoint
+runners:
+  greq:
+    addr: localhost:9090
+    tls: false
+    protos:
+      - ../proto/fileservice/v1/file_service.proto # Corrected protos path
+    importPaths:
+      - "." # This will be relative to the runbook's directory if --cwd is not used, or CWD if it is.
+            # For protos, it's often simpler to make proto paths relative to an importPath.
+            # Let's adjust importPaths to be the repo root for clarity with protos.
+      - ../ # Adding repo root as an import path
+vars:
+  uploadDir: "test_uploads" # Must match the upload_and_list.yml
+  fileNameInArchive: "test.txt" # Must match the upload_and_list.yml
+steps:
+  list_grpc:
+    desc: List files via gRPC
+    greq:
+      fileservice.v1.FileService/ListDirectory:
+        message:
+          directory: "{{ vars.uploadDir }}"
+    test: |
+      len(filter(current.res.message.entries, {.name == vars.fileNameInArchive})) > 0

--- a/runn/healthz.yml
+++ b/runn/healthz.yml
@@ -1,0 +1,15 @@
+version: "0"
+desc: Test Healthz endpoint
+runners:
+  req:
+    endpoint: http://localhost:8080
+steps:
+  healthz:
+    desc: Check /healthz endpoint
+    req:
+      /healthz:
+        get:
+          body: null
+    test: |
+      current.res.status == 200
+// vim: filetype=yaml

--- a/runn/upload_and_list.yml
+++ b/runn/upload_and_list.yml
@@ -1,0 +1,29 @@
+version: "0"
+desc: Test Upload and List endpoints
+runners:
+  req:
+    endpoint: http://localhost:8080
+vars:
+  testFile: /app/runn/test.txt # Relative path for runn
+  uploadDir: "test_uploads" # Define an upload directory
+  fileNameInArchive: "test.txt" # Name of the file as it will appear after upload
+steps:
+  upload:
+    desc: Upload a file
+    req:
+      /:
+        post:
+          body:
+            multipart/form-data:
+              path: "{{ vars.uploadDir }}" # Specify the destination path
+              tarfile: "{{ vars.testFile }}"
+    test: |
+      current.res.status == 200
+  list:
+    desc: List files and verify upload
+    req:
+      /list?d={{ vars.uploadDir }}: # Use query parameter 'd'
+        get:
+          body: null
+    test: |
+      current.res.status == 200 && len(filter(current.res.body.Entries, {.Name == vars.fileNameInArchive})) > 0 # Corrected assertion


### PR DESCRIPTION
This commit introduces E2E tests for the file service using runn. Tests cover the /healthz, file upload, HTTP list, and gRPC list functionalities.

The following runbooks were added:
- runn/healthz.yml: Checks the health check endpoint.
- runn/upload_and_list.yml: Tests file upload via HTTP POST and subsequent listing via HTTP GET.
- runn/grpc_list.yml: Tests listing files via the gRPC endpoint.

All tests pass except for one assertion in runn/upload_and_list.yml. The HTTP GET /list endpoint does not immediately reflect the presence of the uploaded file within that specific runbook, even with a delay introduced. However, the gRPC list test, which runs afterwards, successfully finds the uploaded file in the same directory. This suggests a potential runtime behavior or caching effect within the HTTP list handler of the application.

The tests are executed by running 'runn run runn/*.yml' after starting the application.