### PR TITLE
Integrate runn scenario testing into CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           go-version: '1.24.2'
 
+      - name: Install runn
+        run: go install github.com/k1LoW/runn/cmd/runn@latest
+
       - name: Format
         run: |
           files=$(gofmt -l ./)
@@ -32,6 +35,15 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.1
+
+      - name: Build application
+        run: go build -o app .
+
+      - name: Start application
+        run: nohup ./app &
+
+      - name: Run runn tests
+        run: $(go env GOPATH)/bin/runn run runn/**/*.yml
 
       - name: Test
         run: go test -v ./...


### PR DESCRIPTION
This change integrates runn into the GitHub Actions workflow:

- Installs `runn` CLI tool.
- Builds the Go application.
- Starts the application in the background.
- Executes `runn` scenarios located in the `runn/` directory.

This ensures that scenario tests are automatically run as part of the CI pipeline.